### PR TITLE
搜索词变更时重置页码，列表长度变化时调整页码有效性

### DIFF
--- a/src/components/VideoTable.vue
+++ b/src/components/VideoTable.vue
@@ -172,6 +172,19 @@ export default {
     watch(pageSize, () => {
       currentPage.value = 1
     })
+    
+    // 当搜索词变化时，重置到第一页，避免在其他页筛选后看不到结果的情况
+    watch(() => props.searchTerm, () => {
+      currentPage.value = 1
+    })
+
+    // 当视频列表长度变化（例如应用筛选）时，确保 currentPage 在可用范围内
+    watch(() => props.videos.length, (newLen) => {
+      // 计算可能的页数并把 currentPage 夹在 1..totalPages 之间
+      if (currentPage.value > totalPages.value) {
+        currentPage.value = Math.max(1, totalPages.value)
+      }
+    })
 
     return {
       currentPage,


### PR DESCRIPTION
- 当搜索词改变时，将当前页码重置为1，确保用户从第一页开始浏览结果，避免页码超出有效范围的问题。

- 当视频列表长度变化时，调整当前页码使其始终保持在有效范围内，避免页码超出有效范围的问题。