### PR TITLE
fix: 修正 GitHub Pages 的数据更新时间显示

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -103,7 +103,7 @@ export default {
       currentFilterState.statusFilter = statusFilter
     }
 
-    // 加载视频数据
+    // 加载视频数据，并获取 Last-Modified 作为更新时间
     const loadVideoData = async () => {
       try {
         loading.value = true
@@ -116,26 +116,25 @@ export default {
         }
         
         allVideos.value = await response.json()
-        updateDataTimestamp()
+        // 获取 Last-Modified 头
+        const lastModified = response.headers.get('Last-Modified')
+        if (lastModified) {
+          const date = new Date(lastModified)
+          dataUpdateTime.value = date.toLocaleString('zh-CN', {
+            year: 'numeric',
+            month: '2-digit',
+            day: '2-digit',
+            hour: '2-digit',
+            minute: '2-digit',
+            hour12: false
+          })
+        }
       } catch (err) {
         console.error('加载视频失败:', err)
         error.value = err.message
       } finally {
         loading.value = false
       }
-    }
-
-    // 更新数据时间戳
-    const updateDataTimestamp = () => {
-      const now = new Date()
-      dataUpdateTime.value = now.toLocaleDateString('zh-CN', {
-        year: 'numeric',
-        month: '2-digit',
-        day: '2-digit',
-        hour: '2-digit',
-        minute: '2-digit',
-        hour12: false
-      })
     }
 
     // 组件挂载时加载数据


### PR DESCRIPTION
此前，GitHub Pages 底部显示的“数据更新于...”时间戳反映的是网页打开时间，而非 `videos.json` 文件的实际更新时间。本次提交修改了逻辑，以从 `videos.json` 文件中正确获取并显示最后更新的时间戳。

fix #10