### PR TITLE
chore(ci): 新增自动标记新PR的工作流

### DIFF
--- a/.github/workflows/label_new_pr.yml
+++ b/.github/workflows/label_new_pr.yml
@@ -1,0 +1,20 @@
+name: 'Assign Triage Label to New PRs'
+on:
+  pull_request_target:
+    types: [opened]
+jobs:
+  labeler:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - name: 'Add "Status: Triage" label'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            github.rest.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              labels: ['Status: Triage']
+            });


### PR DESCRIPTION
本工作流会自动为所有新开启的拉取请求添加"Status: Triage"标签。

该流程通过确保每个新PR具备清晰初始状态，帮助标准化PR管理流程，便于维护者追踪和审核新提交的贡献。

## Sourcery 总结

CI:
- 添加一个名为 '为新 PR 分配 Triage 标签' 的工作流，该工作流会在 PR 打开时，为新 PR 打上 'Status: Triage' 标签

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

CI:
- Add a 'Assign Triage Label to New PRs' workflow that tags new PRs with 'Status: Triage' upon opening

</details>