### PR TITLE
fix(VideoRow): 通过替换v-html为安全高亮方案解决XSS漏洞

### DIFF
--- a/src/components/VideoRow.vue
+++ b/src/components/VideoRow.vue
@@ -8,8 +8,9 @@
             target="_blank" 
             rel="noopener noreferrer"
             class="video-link"
-            v-html="highlightedTitle"
-          ></a>
+          >
+          {{ highlightedTitle[0] }} <span v-if="highlightedTitle[1]" class="highlight"> {{ highlightedTitle[1] }} </span> {{ highlightedTitle[2] }}
+        </a>
         </VideoTooltip>
       </div>
       <div class="video-meta">
@@ -20,7 +21,9 @@
       </div>
     </td>
     <td>
-      <span v-html="highlightedUploader"></span>
+      <span>
+        {{ highlightedUploader[0] }} <span v-if="highlightedUploader[1]" class="highlight"> {{ highlightedUploader[1] }} </span> {{ highlightedUploader[2] }}
+      </span>
     </td>
     <td>{{ video.created ? formatDate(video.created) : '未知日期' }}</td>
     <td>
@@ -100,18 +103,28 @@ export default {
       partsExpanded.value = !partsExpanded.value
     }
 
-    // 高亮搜索词
+    // 安全的高亮函数，返回一个数组: [before, match, after]
     const highlightSearchTerm = (text) => {
-      if (!props.searchTerm || !text) return text
+      const safeText = text || ''  // 确保text不为null或undefined
+      if (!props.searchTerm) {
+        return [safeText, '', '']  // 没有搜索词时直接返回原始文本
+      }
       
       const term = props.searchTerm.toLowerCase()
       const lowerText = text.toLowerCase()
       const startIndex = lowerText.indexOf(term)
       
-      if (startIndex === -1) return text
+      if (startIndex === -1) {
+        return [safeText, '', '']
+      }
       
       const endIndex = startIndex + term.length
-      return `${text.substring(0, startIndex)}<span class="highlight">${text.substring(startIndex, endIndex)}</span>${text.substring(endIndex)}`
+      // 返回三段纯文本
+      return [
+        safeText.substring(0, startIndex),
+        safeText.substring(startIndex, endIndex),
+        safeText.substring(endIndex)
+      ]
     }
 
     // 计算总时长


### PR DESCRIPTION
将用于搜索词高亮的危险`v-html`指令替换为安全的手动渲染方案。

新实现在组件脚本中将文本拆分为三部分（[匹配前文本，匹配文本，匹配后文本]），模板随后使用标准且自动转义的胡子语法（`{{ }}`）渲染这些部分，并通过硬编码的`<span>`标签实现匹配文本高亮。

此项变更在保留高亮功能的同时，彻底消除了跨站脚本（XSS）攻击漏洞。

## Sourcery 总结

将 VideoRow 组件中搜索词高亮的不安全 HTML 渲染替换为一种手动、自动转义的渲染方法，以消除 XSS 漏洞。

Bug 修复:
- 通过移除 VideoRow.vue 中用于搜索词高亮的 v-html 使用，消除 XSS 漏洞。

增强功能:
- 实现安全的 highlightSearchTerm 函数，该函数返回文本片段，并使用 moustache 语法和一个硬编码的 `<span>` 标签进行渲染以实现高亮。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Replace unsafe HTML rendering of search term highlights in the VideoRow component with a manual, auto-escaped rendering approach to eliminate XSS vulnerabilities.

Bug Fixes:
- Eliminate XSS vulnerability by removing v-html usage for search term highlighting in VideoRow.vue

Enhancements:
- Implement safe highlightSearchTerm function that returns text segments and render them using moustache syntax and a hardcoded <span> for highlighting

</details>